### PR TITLE
fix(sd): Add retry logic for intermittent SD card detection

### DIFF
--- a/src/core/config.h
+++ b/src/core/config.h
@@ -79,6 +79,7 @@ public:
     static bool load();
     static bool loadPersonality();
     static bool isSDAvailable();
+    static bool reinitSD();  // Try to (re)initialize SD card at runtime
     static bool loadWpaSecKeyFromFile();  // Load key from /wpasec_key.txt and delete file
     static bool loadWigleKeyFromFile();   // Load keys from /wigle_key.txt and delete file
     


### PR DESCRIPTION
Problem:
- SD card not always detected at boot on M5Cardputer / Cardputer ADV
- Single SD.begin() call at 25MHz with no retry
- No stabilization delay after M5.begin() for SPI bus settling
- Once sdAvailable flag is false, no way to recover

Root cause:
- ESP32-S3 GPIO 12 is a strapping pin with timing quirks
- SPI bus shared with display needs time to settle
- Some SD cards need slower initial SPI speed
- M5Cardputer v1.1/ADV share SPI bus between display and SD

Solution:
- Add 50ms stabilization delay before SD init
- Retry up to 3x with progressive SPI speeds (10→20→25 MHz)
- Call SD.end() between failed attempts to clean up
- Add reinitSD() function for runtime recovery
- 100ms delay between retry attempts

Testing:
- Build verified: RAM 22%, Flash 52%, 1.6MB binary
- Tested on M5Cardputer ADV

Files changed:
- src/core/config.cpp: SD init retry logic + reinitSD()
- src/core/config.h: reinitSD() declaration