### PR TITLE
HOGWASH - Karma AP

### DIFF
--- a/PR_HOGWASH.md
+++ b/PR_HOGWASH.md
@@ -1,0 +1,126 @@
+# 🐷 HOGWASH Mode - Karma AP Implementation
+
+## Summary
+
+This PR introduces **HOGWASH Mode**, a new operational mode that implements a Karma Access Point attack. The pig listens for WiFi probe requests from nearby devices, extracts the SSIDs they're looking for, and broadcasts a matching fake AP to lure them in.
+
+## 🎯 Features
+
+### Core Karma AP Functionality
+- **Probe Request Capture**: Monitors WiFi probe requests in promiscuous mode
+- **SSID Cycling**: Broadcasts as the last probed SSID to attract devices
+- **Smart Rotation**: SSID cycling pauses while clients are connected (10s disconnect detection)
+- **Hook Detection**: Tracks connected stations with Apple device identification
+- **MAC Randomization Detection**: Shows `[RandomMAC]` when devices use randomized addresses
+
+### Captive Portal
+- **DNS Redirect**: All domains redirect to the AP (192.168.4.1)
+- **HTTP Server**: Serves portal HTML on port 80
+- **Custom Portal**: Drop `/portal.html` on SD card for custom pages
+- **Platform Detection**: Handles Android, iOS, macOS, and Windows captive portal endpoints
+
+### XP & Achievements System
+| Event | XP | Cap |
+|-------|-----|-----|
+| `HOGWASH_PROBE_NEW` | +3 | 200/session |
+| `HOGWASH_HOOK` | +25 | - |
+| `HOGWASH_APPLE_HOOK` | +35 | - |
+| `HOGWASH_SESSION_5MIN` | +10 | - |
+
+**6 New Achievements:**
+- `F1RST H00K` - First device hooked
+- `K4RMA K1NG` - 50 devices hooked lifetime
+- `H0N3Y P0T` - 5 devices connected simultaneously  
+- `TR4P M4ST3R` - 100 unique SSIDs captured
+- `4PPL3 P1CK3R` - Hook 10 Apple devices
+- `TR4FF1C W4RD3N` - 30 minutes continuous operation
+
+### Avatar & Mood
+- **DEVIOUS State**: New sneaky avatar face (`> >` eyes, `~` expression)
+- **Probe Phrases**: "I am [SSID] now", "looking for [SSID]?", etc.
+- **Hook Phrases**: "GOTCHA!", "yoink", "GET OVER HERE"
+- **Mixed Status/Flavor**: 60% stats, 40% flavor phrases during operation
+
+### UI & Settings
+- **Bottom Bar**: Shows `P:probes U:unique H:hooked [SSID]`
+- **Sound Notifications**: Double beep for hooks, triple for Apple devices
+- **Settings**:
+  - `Karma Portal`: Toggle captive portal (default: OFF)
+  - `SSID Cycle`: 1-30 seconds (default: 5s)
+
+## 📁 Files Changed
+
+### New Files
+- `src/modes/hogwash.cpp` - Core implementation (~700 lines)
+- `src/modes/hogwash.h` - Mode interface and structures
+
+### Modified Files
+- `src/core/porkchop.cpp/.h` - Mode integration (K key binding)
+- `src/core/xp.cpp/.h` - XP events and achievements2 field
+- `src/core/config.cpp/.h` - Settings (portal toggle, cycle time)
+- `src/piglet/avatar.cpp/.h` - DEVIOUS state and frames
+- `src/piglet/mood.cpp/.h` - Phrases and onHogwashUpdate()
+- `src/ui/display.cpp` - UI elements and bottom bar
+- `src/ui/settings_menu.cpp` - New settings items
+- `README.md` - Full documentation
+
+### Tests
+- `test/test_hogwash/test_hogwash.cpp` - 33 test cases covering:
+  - SSID queue operations
+  - Probe request parsing
+  - Achievement2 bitfield operations
+  - XP anti-farm cap logic
+  - Captive portal HTML loading
+  - Platform endpoint detection
+
+## 🛡️ Technical Details
+
+### WiFi Stack
+- Uses ESP32 promiscuous mode for probe capture
+- Soft AP with dynamic SSID switching
+- `esp_wifi_set_inactive_time(10)` for fast disconnect detection
+- Mixed ESP-IDF and Arduino WiFi API usage
+
+### Memory
+- RAM: 23.1% (75.5KB / 327KB)
+- Flash: 53.7% (1.69MB / 3.15MB)
+
+### Key Design Decisions
+1. **Deferred XP**: Probe callback runs in WiFi task; XP grants queued for main loop
+2. **achievements2 field**: Uses second uint64_t for HOGWASH achievements (NVS compatible)
+3. **Station Count**: Uses `WiFi.softAPgetStationNum()` for real-time client detection
+4. **Inactivity Timeout**: 10 seconds instead of default 300s for responsive cycling
+
+## ⚠️ Disclaimer
+
+HOGWASH mode demonstrates Karma AP attacks for **educational purposes only**. Use responsibly on your own devices. The same legal considerations as PIGGY BLUES apply.
+
+## 📸 Screenshots
+
+The pig displays the DEVIOUS face throughout HOGWASH operation:
+```
+ >  > 
+(~ 00)
+(    )
+```
+
+## Testing
+
+```bash
+# Run HOGWASH tests
+pio test -e native --filter "test_hogwash"
+
+# Build for device
+pio run -e m5cardputer
+
+# Flash and monitor
+pio run -e m5cardputer -t upload && pio device monitor -b 115200
+```
+
+## Commits (17 total)
+
+See individual commit messages for detailed changes. Key commits:
+- `a2e26a4` - Core implementation
+- `38e89f9` - Captive portal
+- `072af77` - SSID rotation fixes
+- `88f00c7` - DEVIOUS avatar persistence

--- a/README.md
+++ b/README.md
@@ -512,8 +512,38 @@
         HOGWASH_APPLE_HOOK: +35 XP for Apple devices (harder targets)
         HOGWASH_SESSION:    +10 XP every 5 minutes active
 
-    Karma Portal setting (Settings > Karma Portal: OFF by default):
-    enable for DNS captive portal redirect. stealth mode? leave it off.
+    settings:
+        Karma Portal: OFF by default. enables captive portal (see below)
+        SSID Cycle:   1-30 seconds (default 5s). how often to switch SSID
+
+    CAPTIVE PORTAL (when Karma Portal: ON):
+    
+        devices connect to your karma AP but have nowhere to go. with the
+        captive portal enabled, they see a fake "connecting..." page instead
+        of a connection error. keeps them hooked longer. looks legit.
+        
+        how it works:
+        
+            * DNS server redirects ALL domains to 192.168.4.1
+            * HTTP server serves portal HTML on port 80
+            * handles platform-specific detection endpoints:
+                - Android: /generate_204, /gen_204
+                - iOS/macOS: /hotspot-detect.html
+                - Windows: /connecttest.txt, /success.txt
+        
+        default portal: pig-branded dark theme with loading spinner and
+        "Connecting you to the internet..." message. looks professional.
+        
+        custom portal: drop /portal.html on your SD card. the pig loads it
+        automatically at mode start. go wild - phishing pages, rickrolls,
+        whatever fits your threat model. just remember: you own the outcome.
+        
+        when portal is active: toast shows "KARMA+PORTAL" instead of
+        "KARMA ACTIVE". you'll know.
+
+    sound notifications:
+        * regular device hook: double ascending beep (1200→1600Hz)
+        * Apple device hook: triple ascending beep (1200→1500→1800Hz)
 
     why devices fall for this: most phones/laptops have "auto-join known
     networks" enabled by default. they probe for remembered SSIDs constantly.

--- a/README.md
+++ b/README.md
@@ -54,18 +54,19 @@
             3.1.2 - Stationary Operation Tuning
         3.2 - WARHOG Mode
         3.3 - PIGGY BLUES Mode
-        3.4 - HOG ON SPECTRUM Mode
-            3.4.1 - CLIENT MONITOR
-        3.5 - PORKCHOP COMMANDER
-        3.6 - LOOT Menu & WPA-SEC Integration
-        3.7 - Machine Learning
-        3.8 - Enhanced ML Mode
-        3.9 - XP System
-            3.9.1 - IMMORTAL PIG
-        3.10 - Achievements
-        3.11 - SWINE STATS
-        3.12 - Session Challenges
-        3.13 - Unlockables
+        3.4 - HOGWASH Mode (Karma AP)
+        3.5 - HOG ON SPECTRUM Mode
+            3.5.1 - CLIENT MONITOR
+        3.6 - PORKCHOP COMMANDER
+        3.7 - LOOT Menu & WPA-SEC Integration
+        3.8 - Machine Learning
+        3.9 - Enhanced ML Mode
+        3.10 - XP System
+            3.10.1 - IMMORTAL PIG
+        3.11 - Achievements
+        3.12 - SWINE STATS
+        3.13 - Session Challenges
+        3.14 - Unlockables
     4 - Hardware
     5 - Building & Flashing
         5.1 - Flashing Methods & Progress Preservation
@@ -469,7 +470,66 @@
     WINDOWS_PANIC, BLE_BOMBER, OINKAGEDDON. you know what to do.
 
 
-----[ 3.4 - HOG ON SPECTRUM Mode
+----[ 3.4 - HOGWASH Mode (Karma AP)
+
+    press 'K' and become the WiFi everyone's looking for.
+
+    your phone constantly whispers the names of WiFi networks it remembers:
+    "Is Home_WiFi here? Is Starbucks_Free here?" probe requests. always.
+    HOGWASH listens to these whispers and lies back: "yes, I'm that network.
+    connect to me!" the phone believes it. auto-associates. hooked.
+
+    bottom bar shows: P:probes U:unique H:hooked [SSID]
+    the [SSID] updates every 5 seconds when a NEW unique probe is captured.
+    no new probes? no change. the pig waits. the pig is patient.
+
+    the attack surface:
+
+        * promiscuous mode probe request capture - hears everything
+        * 8-slot SSID ring buffer - stores recent unique network names
+        * karma AP cycles through captured SSIDs every 5 seconds
+        * devices auto-connect thinking it's their remembered network
+        * Apple OUI detection - bonus XP for hooking iPhones
+        * DHCP server built-in - they get an IP, nowhere to go
+
+    the piglet goes DEVIOUS in this mode. narrowed eyes. sly expression.
+    "come to papa..." and "trust me bro" and "free internet innit".
+    when someone connects: "GOTCHA!" or "yoink" or "GET OVER HERE".
+    the pig knows what it's doing. it's fishing. with WiFi.
+
+    how it works:
+
+        1. ESP32 enters promiscuous mode, listens for probe requests
+        2. extracts SSIDs from Management frames (type 0x40)
+        3. queues unique SSIDs in 8-slot ring buffer with timestamps
+        4. karma AP broadcasts as latest queued SSID
+        5. devices that probe for that SSID auto-associate
+        6. pig celebrates. XP awarded. achievement progress tracked.
+
+    XP events:
+        HOGWASH_PROBE_NEW:   +3 XP per unique SSID (capped at 200 XP/session)
+        HOGWASH_HOOK:       +25 XP per device connected
+        HOGWASH_APPLE_HOOK: +35 XP for Apple devices (harder targets)
+        HOGWASH_SESSION:    +10 XP every 5 minutes active
+
+    Karma Portal setting (Settings > Karma Portal: OFF by default):
+    enable for DNS captive portal redirect. stealth mode? leave it off.
+
+    why devices fall for this: most phones/laptops have "auto-join known
+    networks" enabled by default. they probe for remembered SSIDs constantly.
+    when they hear a beacon matching a probed SSID? they connect. no check.
+    no verification. just vibes. your $1200 iPhone trusts random radios.
+
+    DISCLAIMER: same rules as PIGGY BLUES. educational purposes only.
+    demonstrating Karma attacks on YOUR OWN devices is valid security
+    research. doing this in public spaces makes you a federal problem.
+    tools don't make choices. you do. don't be a tool.
+
+    achievement hunters: F1RST_H00K, K4RMA_K1NG, H0N3Y_P0T, TR4P_M4ST3R,
+    4PPL3_P1CK3R, TR4FF1C_W4RD3N. go fishing.
+
+
+----[ 3.5 - HOG ON SPECTRUM Mode
 
     press 'H' and watch the 2.4GHz band light up like a Christmas tree:
 
@@ -497,7 +557,7 @@
     a client to deauth them directly. Backspace or G0 to bail. simple as.
 
 
-------[ 3.4.1 - CLIENT MONITOR
+------[ 3.5.1 - CLIENT MONITOR
 
     the spectrum got fangs. press Enter on any network to enter the hunt.
 
@@ -548,7 +608,7 @@
     first 4 clients get beeps. after that, quiet. we're hunting, not DJing.
 
 
-----[ 3.5 - PORKCHOP COMMANDER
+----[ 3.6 - PORKCHOP COMMANDER
 
     time to exfil. your pig caught the goods, now get 'em off the device.
 
@@ -590,7 +650,7 @@
     and clicking download. wordlists, configs, whatever fits on the SD.
 
 
-----[ 3.6 - LOOT Menu & WPA-SEC Integration
+----[ 3.7 - LOOT Menu & WPA-SEC Integration
 
     your spoils of war. hit LOOT from the main menu to see what
     you've captured:
@@ -644,7 +704,7 @@
     if it passes and still fails upload, GitHub issues.
 
 
-----[ 3.7 - Machine Learning
+----[ 3.8 - Machine Learning
 
     STATUS: DATA COLLECTION PHASE. THE PIG IS LEARNING. SLOWLY.
     
@@ -701,7 +761,7 @@
     and drop it in. the scaffold is ready. the pig is waiting.
 
 
-----[ 3.8 - Enhanced ML Mode
+----[ 3.9 - Enhanced ML Mode
 
     two collection modes for different threat models:
 
@@ -737,7 +797,7 @@
         * WPS on open network    classic honeypot fingerprint.
 
 
-----[ 3.9 - XP System
+----[ 3.10 - XP System
 
     your piglet has ambitions. every network sniffed, every handshake
     grabbed, every deauth fired - it all counts. the XP system tracks
@@ -798,7 +858,7 @@
     ready to lose your progress.
 
 
-------[ 3.9.1 - IMMORTAL PIG (XP Persistence)
+------[ 3.10.1 - IMMORTAL PIG (XP Persistence)
 
     NVS lives at 0x9000. M5 Burner writes start at 0x0. you see the
     problem. your L38 DARK TANGENT grind? steamrolled. BACON N00B.
@@ -833,7 +893,7 @@
     device binding: ESP32 MAC address baked into signature.
 
 
-----[ 3.10 - Achievements
+----[ 3.11 - Achievements
 
     63 secret badges to prove you're not just grinding mindlessly.
     or maybe you are. either way, proof of pwn.
@@ -849,7 +909,7 @@
     hunt for handshakes.
 
 
-----[ 3.11 - SWINE STATS (Buff System)
+----[ 3.12 - SWINE STATS (Buff System)
 
     press 'S' or hit SWINE STATS in the menu to see your lifetime
     progress and check what buffs/debuffs are currently messing with
@@ -859,7 +919,7 @@
     what's actively buffing or debuffing your pig.
 
 
-----[ 3.11.1 - Class System
+----[ 3.12.1 - Class System
 
     every 5 levels your pig promotes to a new class tier. classes
     grant PERMANENT CUMULATIVE buffs - higher tier = more stacking:
@@ -882,7 +942,7 @@
     -1ms jitter, and +5% on everything. the grind pays off.
 
 
-----[ 3.11.2 - Mood Buffs/Debuffs
+----[ 3.12.2 - Mood Buffs/Debuffs
 
     the mood system ties happiness to mechanics. happy pig = aggressive.
     sad pig = sluggish. keep the meter up and feel the difference.
@@ -932,7 +992,7 @@
     keep the pig happy. happy pig = effective pig.
 
 
-----[ 3.12 - Session Challenges
+----[ 3.13 - Session Challenges
 
     three challenges spawn each boot. EASY, MEDIUM, HARD. difficulty
     scales with your level. complete all three for bonus XP.
@@ -957,7 +1017,7 @@
     bored, if you know what to ask. just one. pig persists.
 
 
-----[ 3.13 - Unlockables
+----[ 3.14 - Unlockables
 
     two secrets hide in the unlockables menu. SHA256 validated.
     type the phrase, press enter, watch the hash match or fail.

--- a/README.md
+++ b/README.md
@@ -535,8 +535,7 @@
         "Connecting you to the internet..." message. looks professional.
         
         custom portal: drop /portal.html on your SD card. the pig loads it
-        automatically at mode start. go wild - phishing pages, rickrolls,
-        whatever fits your threat model. just remember: you own the outcome.
+        automatically at mode start.
         
         when portal is active: toast shows "KARMA+PORTAL" instead of
         "KARMA ACTIVE". you'll know.
@@ -544,6 +543,16 @@
     sound notifications:
         * regular device hook: double ascending beep (1200→1600Hz)
         * Apple device hook: triple ascending beep (1200→1500→1800Hz)
+
+    smart behaviors:
+        * SSID rotation pauses while clients are connected (resumes on disconnect)
+        * disconnection detected within ~10 seconds (fast timeout)
+        * new probes still queue for XP even while rotation is paused
+
+    note on MAC randomization: modern devices (iOS 14+, Android 10+) randomize
+    their MAC addresses. the pig shows [RandomMAC] in logs when detected. each
+    reconnection from a randomized device appears as a new unique hook. this is
+    expected behavior - there's no way to correlate randomized MACs.
 
     why devices fall for this: most phones/laptops have "auto-join known
     networks" enabled by default. they probe for remembered SSIDs constantly.

--- a/README.md
+++ b/README.md
@@ -515,6 +515,18 @@
     settings:
         Karma Portal: OFF by default. enables captive portal (see below)
         SSID Cycle:   1-30 seconds (default 5s). how often to switch SSID
+        Fixed SSID:   empty by default. if set, enables Evil Twin mode
+
+    MODES:
+    
+        karma mode (default - Fixed SSID empty):
+            the pig listens for probe requests and becomes whatever network
+            devices are looking for. SSID cycles through captured probes.
+            
+        evil twin mode (Fixed SSID set):
+            the pig broadcasts a specific SSID you configure. no cycling,
+            no karma. useful for cloning a specific target network.
+            toast shows "EVIL TWIN" instead of "KARMA ACTIVE".
 
     CAPTIVE PORTAL (when Karma Portal: ON):
     

--- a/src/build_info.h
+++ b/src/build_info.h
@@ -1,5 +1,5 @@
 // Auto-generated build info
 #pragma once
-#define BUILD_TIME "2025-12-27T14:46:48.025685"
+#define BUILD_TIME "2025-12-29T18:41:28.163217"
 #define BUILD_VERSION "0.1.7_DNKROZ"
-#define BUILD_COMMIT "7f7ff6a"
+#define BUILD_COMMIT "0111f65"

--- a/src/build_info.h
+++ b/src/build_info.h
@@ -1,5 +1,5 @@
 // Auto-generated build info
 #pragma once
-#define BUILD_TIME "2025-12-29T18:41:28.163217"
+#define BUILD_TIME "2025-12-30T11:32:42.064175"
 #define BUILD_VERSION "0.1.7_DNKROZ"
-#define BUILD_COMMIT "0111f65"
+#define BUILD_COMMIT "88f00c7"

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -185,6 +185,8 @@ bool Config::load() {
         wifiConfig.wpaSecKey = doc["wifi"]["wpaSecKey"] | "";
         wifiConfig.wigleApiName = doc["wifi"]["wigleApiName"] | "";
         wifiConfig.wigleApiToken = doc["wifi"]["wigleApiToken"] | "";
+        wifiConfig.hogwashCaptivePortal = doc["wifi"]["hogwashCaptivePortal"] | false;
+        wifiConfig.hogwashSSIDCycleMs = doc["wifi"]["hogwashSSIDCycleMs"] | 5000;
     }
     
     // BLE config (PIGGY BLUES)
@@ -298,6 +300,8 @@ bool Config::save() {
     doc["wifi"]["wpaSecKey"] = wifiConfig.wpaSecKey;
     doc["wifi"]["wigleApiName"] = wifiConfig.wigleApiName;
     doc["wifi"]["wigleApiToken"] = wifiConfig.wigleApiToken;
+    doc["wifi"]["hogwashCaptivePortal"] = wifiConfig.hogwashCaptivePortal;
+    doc["wifi"]["hogwashSSIDCycleMs"] = wifiConfig.hogwashSSIDCycleMs;
     
     // BLE config (PIGGY BLUES)
     doc["ble"]["burstInterval"] = bleConfig.burstInterval;

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -187,6 +187,9 @@ bool Config::load() {
         wifiConfig.wigleApiToken = doc["wifi"]["wigleApiToken"] | "";
         wifiConfig.hogwashCaptivePortal = doc["wifi"]["hogwashCaptivePortal"] | false;
         wifiConfig.hogwashSSIDCycleMs = doc["wifi"]["hogwashSSIDCycleMs"] | 5000;
+        const char* fixedSSID = doc["wifi"]["hogwashFixedSSID"] | "";
+        strncpy(wifiConfig.hogwashFixedSSID, fixedSSID, 32);
+        wifiConfig.hogwashFixedSSID[32] = '\0';
     }
     
     // BLE config (PIGGY BLUES)
@@ -302,6 +305,7 @@ bool Config::save() {
     doc["wifi"]["wigleApiToken"] = wifiConfig.wigleApiToken;
     doc["wifi"]["hogwashCaptivePortal"] = wifiConfig.hogwashCaptivePortal;
     doc["wifi"]["hogwashSSIDCycleMs"] = wifiConfig.hogwashSSIDCycleMs;
+    doc["wifi"]["hogwashFixedSSID"] = wifiConfig.hogwashFixedSSID;
     
     // BLE config (PIGGY BLUES)
     doc["ble"]["burstInterval"] = bleConfig.burstInterval;

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -49,6 +49,8 @@ struct WiFiConfig {
     String wpaSecKey = "";              // WPA-SEC.stanev.org user key (32 hex chars)
     String wigleApiName = "";           // WiGLE API Name (from wigle.net/account)
     String wigleApiToken = "";          // WiGLE API Token (from wigle.net/account)
+    bool hogwashCaptivePortal = false;  // Enable DNS captive portal in HOGWASH mode (v0.1.9)
+    uint16_t hogwashSSIDCycleMs = 5000; // SSID cycle interval in ms (1000-30000)
 };
 
 // BLE settings for PIGGY BLUES mode

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -51,6 +51,7 @@ struct WiFiConfig {
     String wigleApiToken = "";          // WiGLE API Token (from wigle.net/account)
     bool hogwashCaptivePortal = false;  // Enable DNS captive portal in HOGWASH mode (v0.1.9)
     uint16_t hogwashSSIDCycleMs = 5000; // SSID cycle interval in ms (1000-30000)
+    char hogwashFixedSSID[33] = "";     // Fixed SSID for Evil Twin mode (empty = karma mode)
 };
 
 // BLE settings for PIGGY BLUES mode

--- a/src/core/porkchop.cpp
+++ b/src/core/porkchop.cpp
@@ -18,6 +18,7 @@
 #include "../modes/donoham.h"
 #include "../modes/warhog.h"
 #include "../modes/piggyblues.h"
+#include "../modes/hogwash.h"
 #include "../modes/spectrum.h"
 #include "../modes/call_papa.h"
 #include "../web/fileserver.h"
@@ -82,6 +83,7 @@ void Porkchop::init() {
         {"DONOHAM", 14, "JAH BLESS DI RX"},
         {"WARHOG", 2, "OSCAR MIKE WITH GPS"},
         {"PIGGY BLUES", 8, "SLAY ON BLEAY"},
+        {"HOGWASH", 17, "KARMA IS REAL"},
         {"CALL PIG JUNIOR", 16, "SYNC FROM SIRLOIN"},
         {"HOG ON SPECTRUM", 10, "NIETZSCHE KNOWS"},
         // === DATA & STATS ===
@@ -119,6 +121,7 @@ void Porkchop::init() {
             case 14: setMode(PorkchopMode::DNH_MODE); break;
             case 15: setMode(PorkchopMode::UNLOCKABLES); break;
             case 16: setMode(PorkchopMode::CALL_PAPA_MODE); break;
+            case 17: setMode(PorkchopMode::HOGWASH_MODE); break;
         }
         Menu::clearSelected();
     });
@@ -160,7 +163,8 @@ void Porkchop::setMode(PorkchopMode mode) {
         currentMode != PorkchopMode::SWINE_STATS &&
         currentMode != PorkchopMode::BOAR_BROS &&
         currentMode != PorkchopMode::WIGLE_MENU &&
-        currentMode != PorkchopMode::UNLOCKABLES) {
+        currentMode != PorkchopMode::UNLOCKABLES &&
+        currentMode != PorkchopMode::HOGWASH_MODE) {
         previousMode = currentMode;
     }
     currentMode = mode;
@@ -186,6 +190,9 @@ void Porkchop::setMode(PorkchopMode mode) {
             break;
         case PorkchopMode::PIGGYBLUES_MODE:
             PiggyBluesMode::stop();
+            break;
+        case PorkchopMode::HOGWASH_MODE:
+            HogwashMode::stop();
             break;
         case PorkchopMode::SPECTRUM_MODE:
             SpectrumMode::stop();
@@ -265,6 +272,16 @@ void Porkchop::setMode(PorkchopMode mode) {
             PiggyBluesMode::start();
             // If user aborted warning dialog, return to menu
             if (!PiggyBluesMode::isRunning()) {
+                currentMode = PorkchopMode::MENU;
+                Menu::show();
+            }
+            break;
+        case PorkchopMode::HOGWASH_MODE:
+            Avatar::setState(AvatarState::HUNTING);  // TODO: Add DEVIOUS state
+            SDLog::log("PORK", "Mode: HOGWASH");
+            HogwashMode::start();
+            // If user aborted warning dialog, return to menu
+            if (!HogwashMode::isRunning()) {
                 currentMode = PorkchopMode::MENU;
                 Menu::show();
             }
@@ -401,6 +418,7 @@ void Porkchop::handleInput() {
             currentMode == PorkchopMode::DNH_MODE ||
             currentMode == PorkchopMode::WARHOG_MODE ||
             currentMode == PorkchopMode::PIGGYBLUES_MODE ||
+            currentMode == PorkchopMode::HOGWASH_MODE ||
             currentMode == PorkchopMode::SPECTRUM_MODE) {
             setMode(PorkchopMode::IDLE);
             return;
@@ -462,6 +480,10 @@ void Porkchop::handleInput() {
                 case 'd': // DO NO HAM mode
                 case 'D':
                     setMode(PorkchopMode::DNH_MODE);
+                    break;
+                case 'k': // HOGWASH (Karma AP)
+                case 'K':
+                    setMode(PorkchopMode::HOGWASH_MODE);
                     break;
                 case 'f': // File transfer (PORKCHOP COMMANDER)
                 case 'F':
@@ -551,6 +573,14 @@ void Porkchop::handleInput() {
     
     // PIGGYBLUES mode - Backspace to stop and return to idle
     if (currentMode == PorkchopMode::PIGGYBLUES_MODE) {
+        if (M5Cardputer.Keyboard.isKeyPressed(KEY_BACKSPACE)) {
+            setMode(PorkchopMode::IDLE);
+            return;
+        }
+    }
+    
+    // HOGWASH mode - Backspace to stop and return to idle
+    if (currentMode == PorkchopMode::HOGWASH_MODE) {
         if (M5Cardputer.Keyboard.isKeyPressed(KEY_BACKSPACE)) {
             setMode(PorkchopMode::IDLE);
             return;
@@ -666,6 +696,9 @@ void Porkchop::updateMode() {
             break;
         case PorkchopMode::PIGGYBLUES_MODE:
             PiggyBluesMode::update();
+            break;
+        case PorkchopMode::HOGWASH_MODE:
+            HogwashMode::update();
             break;
         case PorkchopMode::SPECTRUM_MODE:
             SpectrumMode::update();

--- a/src/core/porkchop.h
+++ b/src/core/porkchop.h
@@ -12,6 +12,7 @@ enum class PorkchopMode : uint8_t {
     DNH_MODE,       // DO NO HAM - passive recon (no attacks)
     WARHOG_MODE,    // Wardriving mode
     PIGGYBLUES_MODE,// BLE notification spam
+    HOGWASH_MODE,   // Karma AP - probe response honeypot
     SPECTRUM_MODE,  // WiFi spectrum analyzer
     MENU,           // Menu navigation
     SETTINGS,       // Settings screen

--- a/src/core/xp.h
+++ b/src/core/xp.h
@@ -52,7 +52,12 @@ enum class XPEvent : uint8_t {
     DNH_NETWORK_PASSIVE,    // +2 XP - network found in passive mode
     DNH_PMKID_GHOST,        // +100 XP - PMKID captured passively (rare!)
     BOAR_BRO_ADDED,         // +5 XP - added network to BOAR BROS
-    BOAR_BRO_MERCY          // +15 XP - excluded mid-attack target
+    BOAR_BRO_MERCY,         // +15 XP - excluded mid-attack target
+    // HOGWASH (Karma AP) events (v0.1.9+)
+    HOGWASH_PROBE_NEW,      // +3 XP - new unique SSID probed
+    HOGWASH_HOOK,           // +25 XP - device connected to fake AP
+    HOGWASH_APPLE_HOOK,     // +35 XP - Apple device hooked (bonus)
+    HOGWASH_SESSION_5MIN    // +10 XP - 5 minutes of HOGWASH running
 };
 
 // Achievement bitflags (uint64_t for 60 achievements)
@@ -152,6 +157,17 @@ enum PorkAchievement : uint64_t {
     ACH_FULL_CLEAR      = 1ULL << 63,  // All other achievements unlocked (TH3_C0MPL3T10N1ST)
 };
 
+// HOGWASH achievements (achievements2 bitfield, bits 0-7) - v0.1.9
+enum HogwashAchievement : uint64_t {
+    HACH_NONE           = 0,
+    HACH_F1RST_H00K     = 1ULL << 0,   // First device connected via Karma AP
+    HACH_K4RMA_K1NG     = 1ULL << 1,   // 50 devices hooked lifetime
+    HACH_H0N3Y_P0T      = 1ULL << 2,   // 5 devices connected simultaneously
+    HACH_TR4P_M4ST3R    = 1ULL << 3,   // 100 unique SSIDs captured
+    HACH_4PPL3_P1CK3R   = 1ULL << 4,   // Hook 10 Apple devices
+    HACH_TR4FF1C_W4RD3N = 1ULL << 5,   // 30 minutes continuous HOGWASH
+};
+
 // Persistent XP data structure (stored in NVS)
 struct PorkXPData {
     uint32_t totalXP;           // Lifetime XP
@@ -180,6 +196,10 @@ struct PorkXPData {
     uint32_t mercyCount;        // Mid-attack exclusions (mercy kills)
     TitleOverride titleOverride; // Player-selected title override
     uint32_t unlockables;       // Unlockables bitfield (v0.1.8) - secret challenges
+    // HOGWASH persistent counters (v0.1.9+)
+    uint64_t achievements2;     // Second achievement bitfield for HOGWASH (bits 0-63)
+    uint32_t lifetimeHooks;     // Total devices hooked in HOGWASH
+    uint32_t lifetimeProbes;    // Total unique SSIDs seen
 };
 
 // Session-only stats (not persisted)
@@ -208,6 +228,10 @@ struct SessionStats {
     uint32_t boarBrosThisSession; // Bros added this session (for PACIFIST_RUN)
     uint32_t mercyCount;        // Mid-attack exclusions this session
     bool everDeauthed;          // Has player ever sent deauth? (for Silent Witness)
+    // HOGWASH session counters (v0.1.9+)
+    uint32_t hogwashProbes;     // Unique SSIDs seen this session
+    uint32_t hogwashHooks;      // Devices hooked this session
+    uint16_t hogwashProbeXP;    // XP from probes this session (capped at 200)
 };
 
 class XP {
@@ -250,6 +274,12 @@ public:
     static uint64_t getAchievements();
     static uint8_t getUnlockedCount();  // Count of unlocked achievements
     static const char* getAchievementName(PorkAchievement ach);
+    
+    // HOGWASH Achievements (achievements2, v0.1.9)
+    static void unlockAchievement2(HogwashAchievement ach);
+    static bool hasAchievement2(HogwashAchievement ach);
+    static uint64_t getAchievements2();
+    static const char* getAchievement2Name(HogwashAchievement ach);
     
     // Unlockables (v0.1.8) - secret challenges
     static void setUnlockable(uint8_t bitIndex);

--- a/src/modes/hogwash.cpp
+++ b/src/modes/hogwash.cpp
@@ -190,8 +190,9 @@ void HogwashMode::update() {
         Serial.printf("[HOGWASH] XP granted for new SSID: %s\n", pendingSSID);
     }
     
-    // Cycle SSID periodically
-    if (now - lastSSIDChange > ssidCycleIntervalMs) {
+    // Cycle SSID periodically (but NOT while clients are connected)
+    // Changing SSID disconnects all clients, so pause rotation to keep hooks alive
+    if (hookedCount == 0 && now - lastSSIDChange > ssidCycleIntervalMs) {
         cycleToNextSSID();
         lastSSIDChange = now;
     }

--- a/src/modes/hogwash.cpp
+++ b/src/modes/hogwash.cpp
@@ -1,0 +1,533 @@
+// HOGWASH Mode Implementation - Karma AP
+// Responds to probe requests with matching SSIDs to lure devices
+//
+// Technical notes:
+// - Uses ESP32 promiscuous mode to capture probe requests
+// - Runs soft AP with dynamically changing SSID
+// - Tracks connected stations for XP awards
+//
+// Achievement storage note:
+// HOGWASH achievements use the second uint64_t bitfield (achievements2)
+// This was chosen over __uint128_t because:
+// - Native 64-bit operations on ESP32 (no software emulation)
+// - Easy NVS storage (two putUInt calls, existing pattern)
+// - Backward compatible with existing save format
+
+#include "hogwash.h"
+#include "../core/config.h"
+#include "../core/xp.h"
+#include "../core/sdlog.h"
+#include "../ui/display.h"
+#include "../piglet/mood.h"
+#include "../piglet/avatar.h"
+#include <M5Cardputer.h>
+#include <WiFi.h>
+#include <esp_wifi.h>
+
+// Static member initialization
+bool HogwashMode::running = false;
+bool HogwashMode::confirmed = false;
+SSIDEntry HogwashMode::ssidQueue[HOGWASH_SSID_QUEUE_SIZE] = {0};
+uint8_t HogwashMode::ssidQueueHead = 0;
+uint8_t HogwashMode::ssidQueueCount = 0;
+char HogwashMode::currentSSID[33] = {0};
+uint32_t HogwashMode::lastSSIDChange = 0;
+uint16_t HogwashMode::ssidCycleIntervalMs = 5000;  // 5 seconds per SSID
+std::vector<HookedStation> HogwashMode::hookedStations;
+uint8_t HogwashMode::hookedCount = 0;
+uint8_t HogwashMode::appleHookCount = 0;
+uint32_t HogwashMode::probeCount = 0;
+uint32_t HogwashMode::uniqueSSIDCount = 0;
+uint32_t HogwashMode::sessionStartTime = 0;
+uint16_t HogwashMode::sessionProbeXP = 0;
+bool HogwashMode::probeXPCapWarned = false;
+uint8_t HogwashMode::channel = 6;
+
+// Deferred XP queue (callback runs in WiFi task, XP must be granted in main loop)
+static volatile bool pendingNewSSID = false;
+static char pendingSSID[33] = {0};
+
+// Pig phrases for HOGWASH mode
+static const char* HOGWASH_PHRASES_IDLE[] = {
+    "come to papa...",
+    "here piggy piggy...",
+    "the wifi is free...",
+    "trust me bro",
+    "totally legit network"
+};
+static const uint8_t HOGWASH_PHRASES_IDLE_COUNT = 5;
+
+static const char* HOGWASH_PHRASES_HOOK[] = {
+    "GOTCHA!",
+    "welcome to the farm",
+    "another one",
+    "yoink",
+    "GET OVER HERE"
+};
+static const uint8_t HOGWASH_PHRASES_HOOK_COUNT = 5;
+
+void HogwashMode::init() {
+    running = false;
+    confirmed = false;
+    memset(ssidQueue, 0, sizeof(ssidQueue));
+    ssidQueueHead = 0;
+    ssidQueueCount = 0;
+    memset(currentSSID, 0, sizeof(currentSSID));
+    hookedStations.clear();
+    hookedCount = 0;
+    appleHookCount = 0;
+    probeCount = 0;
+    uniqueSSIDCount = 0;
+    sessionStartTime = 0;
+    sessionProbeXP = 0;
+    probeXPCapWarned = false;
+}
+
+void HogwashMode::start() {
+    if (running) return;
+    
+    // Show warning dialog (same pattern as PIGGYBLUES)
+    if (!confirmed) {
+        if (!showWarningDialog()) {
+            return;  // User cancelled
+        }
+        confirmed = true;
+    }
+    
+    // Reset session stats
+    memset(ssidQueue, 0, sizeof(ssidQueue));
+    ssidQueueHead = 0;
+    ssidQueueCount = 0;
+    hookedStations.clear();
+    hookedCount = 0;
+    appleHookCount = 0;
+    probeCount = 0;
+    uniqueSSIDCount = 0;
+    sessionStartTime = millis();
+    sessionProbeXP = 0;
+    probeXPCapWarned = false;
+    
+    // Load SSID cycle interval from config
+    ssidCycleIntervalMs = Config::wifi().hogwashSSIDCycleMs;
+    
+    // Start probe monitoring
+    startProbeMonitor();
+    
+    // Initial SSID (will be updated when probes arrive)
+    strcpy(currentSSID, "FreeWiFi");
+    
+    // Start soft AP
+    startSoftAP();
+    
+    running = true;
+    
+    // Set pig mood - DEVIOUS for the scheming karma AP pig
+    Avatar::setState(AvatarState::DEVIOUS);
+    Display::showToast("KARMA ACTIVE");
+    
+    SDLog::log("HOG", "HOGWASH mode started on channel %d", channel);
+    Serial.println("[HOGWASH] Mode started");
+}
+
+void HogwashMode::stop() {
+    if (!running) return;
+    
+    Serial.println("[HOGWASH] Stopping...");
+    
+    // Mark as not running first to stop callback processing
+    running = false;
+    
+    // Stop probe monitoring (disables promiscuous mode)
+    stopProbeMonitor();
+    
+    // Small delay before AP disconnect
+    delay(50);
+    
+    // Stop soft AP
+    stopSoftAP();
+    
+    // Process any pending XP save
+    XP::processPendingSave();
+    
+    // Reset avatar state
+    Avatar::setState(AvatarState::NEUTRAL);
+    
+    SDLog::log("HOG", "HOGWASH stopped: %lu probes, %d hooks", probeCount, hookedCount);
+    Serial.printf("[HOGWASH] Stopped - Probes: %lu, Hooks: %d, Free heap: %lu\n", 
+                  probeCount, hookedCount, (unsigned long)ESP.getFreeHeap());
+}
+
+void HogwashMode::update() {
+    if (!running) return;
+    
+    uint32_t now = millis();
+    
+    // Process deferred XP grant from callback (callback runs in WiFi task)
+    if (pendingNewSSID) {
+        pendingNewSSID = false;
+        XP::addXP(XPEvent::HOGWASH_PROBE_NEW);
+        Serial.printf("[HOGWASH] XP granted for new SSID: %s\n", pendingSSID);
+    }
+    
+    // Cycle SSID periodically
+    if (now - lastSSIDChange > ssidCycleIntervalMs) {
+        cycleToNextSSID();
+        lastSSIDChange = now;
+    }
+    
+    // Check for newly connected stations
+    checkConnectedStations();
+    
+    // Award session time XP (every 5 minutes)
+    uint32_t sessionMinutes = (now - sessionStartTime) / 60000;
+    static uint32_t lastSessionXPMinute = 0;
+    if (sessionMinutes >= 5 && sessionMinutes > lastSessionXPMinute && sessionMinutes % 5 == 0) {
+        XP::addXP(XPEvent::HOGWASH_SESSION_5MIN);
+        lastSessionXPMinute = sessionMinutes;
+    }
+    
+    // Update mood with current stats
+    static uint32_t lastMoodUpdate = 0;
+    if (now - lastMoodUpdate > 3000) {  // Every 3 seconds
+        Mood::onHogwashUpdate(currentSSID, hookedCount, probeCount);
+        lastMoodUpdate = now;
+    }
+}
+
+bool HogwashMode::showWarningDialog() {
+    // Warning dialog styled like PIGGYBLUES - pink box on black background
+    M5Canvas& canvas = Display::getMain();
+    
+    // Dialog dimensions
+    const uint16_t DIALOG_WIDTH = 200;
+    const uint16_t DIALOG_HEIGHT = 70;
+    const uint32_t DIALOG_TIMEOUT_MS = 5000;
+    
+    int boxW = DIALOG_WIDTH;
+    int boxH = DIALOG_HEIGHT;
+    int boxX = (DISPLAY_W - boxW) / 2;
+    int boxY = (MAIN_H - boxH) / 2;
+    
+    uint32_t startTime = millis();
+    uint32_t timeout = DIALOG_TIMEOUT_MS;
+    
+    while ((millis() - startTime) < timeout) {
+        M5.update();
+        M5Cardputer.update();
+        
+        uint32_t remaining = (timeout - (millis() - startTime)) / 1000 + 1;
+        
+        // Clear and redraw
+        canvas.fillSprite(COLOR_BG);
+        
+        // Black border then pink fill
+        canvas.fillRoundRect(boxX - 2, boxY - 2, boxW + 4, boxH + 4, 8, COLOR_BG);
+        canvas.fillRoundRect(boxX, boxY, boxW, boxH, 8, COLOR_FG);
+        
+        // Black text on pink background
+        canvas.setTextColor(COLOR_BG, COLOR_FG);
+        canvas.setTextDatum(top_center);
+        canvas.setTextSize(1);
+        canvas.setFont(&fonts::Font0);
+        
+        int centerX = DISPLAY_W / 2;
+        canvas.drawString("!! WARNING !!", centerX, boxY + 8);
+        canvas.drawString("KARMA AP FAKE NETWORKS", centerX, boxY + 22);
+        canvas.drawString("EDUCATIONAL USE ONLY!", centerX, boxY + 36);
+        
+        char buf[24];
+        snprintf(buf, sizeof(buf), "[Y] Yes  [`] No (%lu)", remaining);
+        canvas.drawString(buf, centerX, boxY + 54);
+        
+        Display::pushAll();
+        
+        if (M5Cardputer.Keyboard.isChange()) {
+            if (M5Cardputer.Keyboard.isKeyPressed('`')) {
+                return false;
+            }
+            if (M5Cardputer.Keyboard.isKeyPressed('y') || M5Cardputer.Keyboard.isKeyPressed('Y')) {
+                return true;
+            }
+        }
+        
+        delay(50);
+    }
+    
+    // Timeout = abort
+    return false;
+}
+
+void HogwashMode::startProbeMonitor() {
+    // Disconnect any existing WiFi
+    WiFi.disconnect();
+    WiFi.mode(WIFI_MODE_NULL);
+    delay(50);
+    
+    // Enable promiscuous mode
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    esp_wifi_init(&cfg);
+    esp_wifi_set_mode(WIFI_MODE_NULL);
+    esp_wifi_start();
+    esp_wifi_set_promiscuous(true);
+    esp_wifi_set_promiscuous_rx_cb(probeCallback);
+    
+    // Set to a common channel
+    esp_wifi_set_channel(channel, WIFI_SECOND_CHAN_NONE);
+    
+    Serial.printf("[HOGWASH] Probe monitor started on channel %d\n", channel);
+}
+
+void HogwashMode::stopProbeMonitor() {
+    esp_wifi_set_promiscuous(false);
+    esp_wifi_set_promiscuous_rx_cb(nullptr);
+}
+
+void HogwashMode::startSoftAP() {
+    // Stop promiscuous mode temporarily
+    // Note: ESP32 can run promiscuous mode and soft AP simultaneously on same channel
+    
+    // Start soft AP with current SSID
+    WiFi.mode(WIFI_AP);
+    WiFi.softAP(currentSSID, nullptr, channel, 0, 4);  // Open network, max 4 connections
+    
+    // Re-enable promiscuous mode
+    esp_wifi_set_promiscuous(true);
+    esp_wifi_set_promiscuous_rx_cb(probeCallback);
+    
+    Serial.printf("[HOGWASH] Soft AP started: %s\n", currentSSID);
+}
+
+void HogwashMode::stopSoftAP() {
+    // Disconnect stations first
+    WiFi.softAPdisconnect(false);  // Don't turn off WiFi yet
+    
+    // Small delay to let disconnect complete
+    delay(100);
+}
+
+void HogwashMode::updateSoftAPSSID() {
+    if (currentSSID[0] == '\0') return;
+    
+    // Change soft AP SSID (requires restart of AP)
+    WiFi.softAPdisconnect(false);
+    WiFi.softAP(currentSSID, nullptr, channel, 0, 4);
+    
+    Serial.printf("[HOGWASH] SSID changed to: %s\n", currentSSID);
+}
+
+void HogwashMode::checkConnectedStations() {
+    wifi_sta_list_t stationList;
+    esp_wifi_ap_get_sta_list(&stationList);
+    
+    // Check for new connections
+    for (int i = 0; i < stationList.num; i++) {
+        wifi_sta_info_t* sta = &stationList.sta[i];
+        
+        // Check if already tracked
+        bool found = false;
+        for (const auto& hooked : hookedStations) {
+            if (memcmp(hooked.mac, sta->mac, 6) == 0) {
+                found = true;
+                break;
+            }
+        }
+        
+        if (!found) {
+            // New connection!
+            HookedStation newSta;
+            memcpy(newSta.mac, sta->mac, 6);
+            newSta.connectedAt = millis();
+            newSta.isApple = (sta->mac[0] & 0x02) == 0 && 
+                            (sta->mac[0] == 0xF0 || sta->mac[0] == 0xAC ||
+                             sta->mac[0] == 0x70 || sta->mac[0] == 0x60);  // Common Apple OUIs
+            
+            hookedStations.push_back(newSta);
+            hookedCount++;
+            if (newSta.isApple) appleHookCount++;
+            
+            // XP award
+            if (newSta.isApple) {
+                XP::addXP(XPEvent::HOGWASH_APPLE_HOOK);
+            } else {
+                XP::addXP(XPEvent::HOGWASH_HOOK);
+            }
+            
+            // First hook achievement
+            if (!XP::hasAchievement2(HACH_F1RST_H00K)) {
+                XP::unlockAchievement2(HACH_F1RST_H00K);
+            }
+            
+            // H0N3Y P0T: 5 devices connected simultaneously
+            if (stationList.num >= 5 && !XP::hasAchievement2(HACH_H0N3Y_P0T)) {
+                XP::unlockAchievement2(HACH_H0N3Y_P0T);
+            }
+            
+            // 4PPL3 P1CK3R: 10 Apple devices hooked lifetime
+            if (appleHookCount >= 10 && !XP::hasAchievement2(HACH_4PPL3_P1CK3R)) {
+                XP::unlockAchievement2(HACH_4PPL3_P1CK3R);
+            }
+            
+            // Show hook phrase and celebratory sound
+            Display::showToast(HOGWASH_PHRASES_HOOK[random(0, HOGWASH_PHRASES_HOOK_COUNT)]);
+            
+            // Celebratory beep for hooked device (similar to handshake capture)
+            if (Config::personality().soundEnabled) {
+                if (newSta.isApple) {
+                    // Apple device = premium catch = triple beep
+                    M5.Speaker.tone(1200, 80);
+                    delay(100);
+                    M5.Speaker.tone(1500, 80);
+                    delay(100);
+                    M5.Speaker.tone(1800, 120);
+                } else {
+                    // Regular hook = double ascending beep
+                    M5.Speaker.tone(1200, 100);
+                    delay(120);
+                    M5.Speaker.tone(1600, 150);
+                }
+            }
+            
+            Serial.printf("[HOGWASH] HOOKED! Station: %02X:%02X:%02X:%02X:%02X:%02X (Apple: %s)\n",
+                          sta->mac[0], sta->mac[1], sta->mac[2],
+                          sta->mac[3], sta->mac[4], sta->mac[5],
+                          newSta.isApple ? "Y" : "N");
+            
+            SDLog::log("HOG", "HOOK: %02X:%02X:%02X:%02X:%02X:%02X",
+                       sta->mac[0], sta->mac[1], sta->mac[2],
+                       sta->mac[3], sta->mac[4], sta->mac[5]);
+        }
+    }
+}
+
+bool HogwashMode::addSSIDToQueue(const char* ssid, uint32_t timestamp) {
+    if (ssid == nullptr || ssid[0] == '\0') return false;
+    if (strlen(ssid) > 32) return false;
+    
+    // Check for duplicate
+    for (uint8_t i = 0; i < ssidQueueCount; i++) {
+        uint8_t idx = (ssidQueueHead + i) % HOGWASH_SSID_QUEUE_SIZE;
+        if (strcmp(ssidQueue[idx].ssid, ssid) == 0) {
+            // Update existing
+            ssidQueue[idx].timestamp = timestamp;
+            ssidQueue[idx].probeCount++;
+            return false;  // Duplicate
+        }
+    }
+    
+    // Add new entry
+    uint8_t newIdx;
+    if (ssidQueueCount < HOGWASH_SSID_QUEUE_SIZE) {
+        newIdx = (ssidQueueHead + ssidQueueCount) % HOGWASH_SSID_QUEUE_SIZE;
+        ssidQueueCount++;
+    } else {
+        // Queue full, overwrite oldest
+        newIdx = ssidQueueHead;
+        ssidQueueHead = (ssidQueueHead + 1) % HOGWASH_SSID_QUEUE_SIZE;
+    }
+    
+    strncpy(ssidQueue[newIdx].ssid, ssid, 32);
+    ssidQueue[newIdx].ssid[32] = '\0';
+    ssidQueue[newIdx].timestamp = timestamp;
+    ssidQueue[newIdx].probeCount = 1;
+    
+    uniqueSSIDCount++;
+    return true;  // New entry
+}
+
+const char* HogwashMode::getLatestSSID() {
+    if (ssidQueueCount == 0) return nullptr;
+    uint8_t latestIdx = (ssidQueueHead + ssidQueueCount - 1) % HOGWASH_SSID_QUEUE_SIZE;
+    return ssidQueue[latestIdx].ssid;
+}
+
+const char* HogwashMode::getLastProbeSSID() {
+    return getLatestSSID();
+}
+
+void HogwashMode::cycleToNextSSID() {
+    const char* nextSSID = getLatestSSID();
+    if (nextSSID != nullptr && strcmp(nextSSID, currentSSID) != 0) {
+        strncpy(currentSSID, nextSSID, 32);
+        currentSSID[32] = '\0';
+        updateSoftAPSSID();
+    }
+}
+
+// Probe request frame type (IEEE 802.11)
+#define WIFI_PKT_MGMT 0
+#define SUBTYPE_PROBE_REQ 0x40
+
+void HogwashMode::probeCallback(void* buf, wifi_promiscuous_pkt_type_t type) {
+    if (!running) return;
+    if (type != WIFI_PKT_MGMT) return;
+    
+    wifi_promiscuous_pkt_t* pkt = (wifi_promiscuous_pkt_t*)buf;
+    const uint8_t* frame = pkt->payload;
+    uint16_t len = pkt->rx_ctrl.sig_len;
+    
+    if (len < 26) return;  // Too short
+    
+    // Check if probe request (type 0x40)
+    uint8_t frameType = frame[0];
+    if (frameType != SUBTYPE_PROBE_REQ) return;
+    
+    probeCount++;
+    
+    // Parse SSID from tagged parameters (offset 24)
+    const uint8_t* tagPtr = frame + 24;
+    const uint8_t* endPtr = frame + len;
+    
+    while (tagPtr + 2 <= endPtr) {
+        uint8_t tagNum = tagPtr[0];
+        uint8_t tagLen = tagPtr[1];
+        
+        if (tagPtr + 2 + tagLen > endPtr) break;
+        
+        if (tagNum == 0) {  // SSID tag
+            if (tagLen == 0 || tagLen > 32) break;  // Broadcast or invalid
+            
+            char ssid[33] = {0};
+            memcpy(ssid, tagPtr + 2, tagLen);
+            ssid[tagLen] = '\0';
+            
+            // Validate printable
+            bool valid = true;
+            for (uint8_t i = 0; i < tagLen; i++) {
+                if (ssid[i] < 32 || ssid[i] > 126) {
+                    valid = false;
+                    break;
+                }
+            }
+            
+            if (valid) {
+                bool isNew = addSSIDToQueue(ssid, millis());
+                
+                if (isNew) {
+                    // DEFERRED: Queue XP grant for main loop (callback runs in WiFi task)
+                    // Direct XP::addXP() calls here don't work correctly
+                    if (!pendingNewSSID) {
+                        strncpy(pendingSSID, ssid, 32);
+                        pendingSSID[32] = '\0';
+                        pendingNewSSID = true;
+                    }
+                    
+                    // Update current SSID immediately for fresh probes
+                    strncpy(currentSSID, ssid, 32);
+                    currentSSID[32] = '\0';
+                    updateSoftAPSSID();
+                    
+                    Serial.printf("[HOGWASH] New probe queued: %s\n", ssid);
+                }
+            }
+            break;
+        }
+        
+        tagPtr += 2 + tagLen;
+    }
+}
+
+void HogwashMode::stationEventHandler(void* arg, esp_event_base_t event_base,
+                                       int32_t event_id, void* event_data) {
+    // Handle station connect/disconnect events
+    // Called from ESP-IDF event loop
+}

--- a/src/modes/hogwash.cpp
+++ b/src/modes/hogwash.cpp
@@ -539,11 +539,15 @@ void HogwashMode::probeCallback(void* buf, wifi_promiscuous_pkt_type_t type) {
                     }
                     
                     // Update current SSID immediately for fresh probes
-                    strncpy(currentSSID, ssid, 32);
-                    currentSSID[32] = '\0';
-                    updateSoftAPSSID();
-                    
-                    Serial.printf("[HOGWASH] New probe queued: %s\n", ssid);
+                    // BUT only if no clients connected (changing SSID disconnects them)
+                    if (hookedCount == 0) {
+                        strncpy(currentSSID, ssid, 32);
+                        currentSSID[32] = '\0';
+                        updateSoftAPSSID();
+                        Serial.printf("[HOGWASH] New probe, switching to: %s\n", ssid);
+                    } else {
+                        Serial.printf("[HOGWASH] New probe queued (clients connected): %s\n", ssid);
+                    }
                 }
             }
             break;

--- a/src/modes/hogwash.cpp
+++ b/src/modes/hogwash.cpp
@@ -76,6 +76,17 @@ static const char* HOGWASH_PHRASES_HOOK[] = {
 };
 static const uint8_t HOGWASH_PHRASES_HOOK_COUNT = 5;
 
+// Phrases when mimicking a new SSID (the %s gets replaced with SSID name)
+static const char* HOGWASH_PHRASES_PROBE[] = {
+    "I am %s now",
+    "yes I'm %s",
+    "looking for %s?",
+    "*becomes %s*",
+    "%s? never heard of it",
+    "totally %s rn"
+};
+static const uint8_t HOGWASH_PHRASES_PROBE_COUNT = 6;
+
 void HogwashMode::init() {
     running = false;
     confirmed = false;
@@ -344,6 +355,18 @@ void HogwashMode::updateSoftAPSSID() {
     // Change soft AP SSID (requires restart of AP)
     WiFi.softAPdisconnect(false);
     WiFi.softAP(currentSSID, nullptr, channel, 0, 4);
+    
+    // Set pig phrase about the new SSID (truncate SSID if needed for display)
+    char phrase[64];
+    char shortSSID[16];
+    strncpy(shortSSID, currentSSID, 12);
+    shortSSID[12] = '\0';
+    if (strlen(currentSSID) > 12) strcat(shortSSID, "...");
+    
+    snprintf(phrase, sizeof(phrase), 
+             HOGWASH_PHRASES_PROBE[random(0, HOGWASH_PHRASES_PROBE_COUNT)], 
+             shortSSID);
+    Mood::setStatusMessage(phrase);
     
     Serial.printf("[HOGWASH] SSID changed to: %s\n", currentSSID);
 }

--- a/src/modes/hogwash.h
+++ b/src/modes/hogwash.h
@@ -1,0 +1,95 @@
+// HOGWASH Mode - Karma AP (Probe Request WiFi Honeypot)
+// Listens for probe requests and responds with matching SSIDs
+// Key: K
+#pragma once
+
+#include <Arduino.h>
+#include <esp_wifi.h>
+#include <vector>
+
+// Maximum SSIDs in the ring buffer
+#define HOGWASH_SSID_QUEUE_SIZE 8
+
+// SSID entry with metadata
+struct SSIDEntry {
+    char ssid[33];      // SSID + null terminator
+    uint32_t timestamp; // When first seen
+    uint8_t probeCount; // How many times probed
+};
+
+// Connected station tracking
+struct HookedStation {
+    uint8_t mac[6];     // Station MAC
+    uint32_t connectedAt; // When connected
+    bool isApple;       // Identified as Apple device
+};
+
+class HogwashMode {
+public:
+    static void init();
+    static void start();
+    static void stop();
+    static void update();
+    static bool isRunning() { return running; }
+    
+    // Statistics
+    static uint32_t getProbeCount() { return probeCount; }
+    static uint32_t getUniqueSSIDCount() { return uniqueSSIDCount; }
+    static uint8_t getHookedCount() { return hookedCount; }
+    static uint8_t getAppleHookCount() { return appleHookCount; }
+    static const char* getCurrentSSID() { return currentSSID; }
+    static const char* getLastProbeSSID();
+    
+private:
+    static bool running;
+    static bool confirmed;  // User confirmed warning dialog
+    
+    // SSID ring buffer
+    static SSIDEntry ssidQueue[HOGWASH_SSID_QUEUE_SIZE];
+    static uint8_t ssidQueueHead;
+    static uint8_t ssidQueueCount;
+    
+    // Current broadcast SSID
+    static char currentSSID[33];
+    static uint32_t lastSSIDChange;
+    static uint16_t ssidCycleIntervalMs;
+    
+    // Connected stations
+    static std::vector<HookedStation> hookedStations;
+    static uint8_t hookedCount;
+    static uint8_t appleHookCount;
+    
+    // Statistics
+    static uint32_t probeCount;
+    static uint32_t uniqueSSIDCount;
+    static uint32_t sessionStartTime;
+    
+    // XP anti-farm
+    static uint16_t sessionProbeXP;
+    static bool probeXPCapWarned;
+    static const uint16_t PROBE_XP_CAP = 200;
+    
+    // Channel
+    static uint8_t channel;
+    
+    // Internal methods
+    static bool showWarningDialog();
+    static void startProbeMonitor();
+    static void stopProbeMonitor();
+    static void startSoftAP();
+    static void stopSoftAP();
+    static void updateSoftAPSSID();
+    static void checkConnectedStations();
+    
+    // SSID queue operations
+    static bool addSSIDToQueue(const char* ssid, uint32_t timestamp);
+    static const char* getLatestSSID();
+    static void cycleToNextSSID();
+    
+    // Probe request callback (registered with esp_wifi)
+    static void probeCallback(void* buf, wifi_promiscuous_pkt_type_t type);
+    
+    // Station event callback
+    static void stationEventHandler(void* arg, esp_event_base_t event_base,
+                                    int32_t event_id, void* event_data);
+};

--- a/src/modes/hogwash.h
+++ b/src/modes/hogwash.h
@@ -92,4 +92,13 @@ private:
     // Station event callback
     static void stationEventHandler(void* arg, esp_event_base_t event_base,
                                     int32_t event_id, void* event_data);
+    
+    // Captive portal
+    static bool portalEnabled;
+    static bool portalRunning;
+    static String portalHTML;
+    static void startCaptivePortal();
+    static void stopCaptivePortal();
+    static void handleCaptivePortal();  // Process DNS and HTTP
+    static void loadPortalHTML();       // Load from SD card
 };

--- a/src/modes/hogwash.h
+++ b/src/modes/hogwash.h
@@ -96,6 +96,7 @@ private:
     // Captive portal
     static bool portalEnabled;
     static bool portalRunning;
+    static bool evilTwinMode;      // Fixed SSID mode (no karma cycling)
     static String portalHTML;
     static void startCaptivePortal();
     static void stopCaptivePortal();

--- a/src/piglet/avatar.cpp
+++ b/src/piglet/avatar.cpp
@@ -85,6 +85,13 @@ const char* AVATAR_ANGRY_R[] = {
     "(    )"
 };
 
+// DEVIOUS: sneaky/scheming expression for HOGWASH mode (narrowed eyes, sly look)
+const char* AVATAR_DEVIOUS_R[] = {
+    " >  > ",
+    "(~ 00)",
+    "(    )"
+};
+
 // Left-looking frames (snout 00 on left side of face, pig looks LEFT, z pigtail)
 const char* AVATAR_NEUTRAL_L[] = {
     " ?  ? ",
@@ -125,6 +132,12 @@ const char* AVATAR_SAD_L[] = {
 const char* AVATAR_ANGRY_L[] = {
     " \\  / ",
     "(00 #)",
+    "(    )z"
+};
+
+const char* AVATAR_DEVIOUS_L[] = {
+    " <  < ",
+    "(00 ~)",
     "(    )z"
 };
 
@@ -307,6 +320,8 @@ void Avatar::draw(M5Canvas& canvas) {
             frame = facingRight ? AVATAR_SAD_R : AVATAR_SAD_L; break;
         case AvatarState::ANGRY:    
             frame = facingRight ? AVATAR_ANGRY_R : AVATAR_ANGRY_L; break;
+        case AvatarState::DEVIOUS:    
+            frame = facingRight ? AVATAR_DEVIOUS_R : AVATAR_DEVIOUS_L; break;
         default:                    
             frame = facingRight ? AVATAR_NEUTRAL_R : AVATAR_NEUTRAL_L; break;
     }

--- a/src/piglet/avatar.h
+++ b/src/piglet/avatar.h
@@ -10,7 +10,8 @@ enum class AvatarState {
     HUNTING,
     SLEEPY,
     SAD,
-    ANGRY
+    ANGRY,
+    DEVIOUS  // HOGWASH mode - sneaky/scheming pig
 };
 
 class Avatar {

--- a/src/piglet/mood.cpp
+++ b/src/piglet/mood.cpp
@@ -1891,13 +1891,20 @@ static const int PHRASES_HOGWASH_STATUS_COUNT = 5;
 void Mood::onHogwashUpdate(const char* ssid, uint8_t hookedCount, uint32_t probeCount) {
     lastActivityTime = millis();
     
-    char buf[48];
+    static char buf[48];
     
     if (hookedCount > 0) {
-        // Status with hook count
-        int idx = random(0, PHRASES_HOGWASH_STATUS_COUNT);
-        snprintf(buf, sizeof(buf), PHRASES_HOGWASH_STATUS[idx], hookedCount, probeCount);
-        currentPhrase = buf;
+        // Mix status phrases with idle/flavor phrases (70% status, 30% flavor)
+        if (random(0, 10) < 7) {
+            // Status with hook count
+            int idx = random(0, PHRASES_HOGWASH_STATUS_COUNT);
+            snprintf(buf, sizeof(buf), PHRASES_HOGWASH_STATUS[idx], hookedCount, probeCount);
+            currentPhrase = buf;
+        } else {
+            // Flavor phrase
+            int idx = random(0, PHRASES_HOGWASH_IDLE_COUNT);
+            currentPhrase = PHRASES_HOGWASH_IDLE[idx];
+        }
         happiness = min(100, happiness + 2);  // Nice boost for hooks
         applyMomentumBoost(10);
     } else if (ssid != nullptr && ssid[0] != '\0') {

--- a/src/piglet/mood.cpp
+++ b/src/piglet/mood.cpp
@@ -1852,3 +1852,63 @@ void Mood::onPiggyBluesUpdate(const char* vendor, int8_t rssi, uint8_t targetCou
     lastPhraseChange = millis();
 }
 
+// HOGWASH (Karma AP) phrases - devious pig luring victims
+const char* PHRASES_HOGWASH_IDLE[] = {
+    "come to papa...",
+    "here piggy piggy...",
+    "the wifi is free...",
+    "trust me bro",
+    "totally legit network",
+    "no password needed",
+    "open sesame bruv",
+    "take the bait...",
+    "free internet innit"
+};
+static const int PHRASES_HOGWASH_IDLE_COUNT = 9;
+
+const char* PHRASES_HOGWASH_HOOKED[] = {
+    "GOTCHA!",
+    "welcome to the farm",
+    "another one",
+    "yoink",
+    "GET OVER HERE",
+    "hook line sinker",
+    "ez catch",
+    "trap sprung",
+    "victim acquired"
+};
+static const int PHRASES_HOGWASH_HOOKED_COUNT = 9;
+
+const char* PHRASES_HOGWASH_STATUS[] = {
+    "%d hooked [%lu probes]",
+    "karma: %d souls captured",
+    "%d victims [%lu sniffed]",
+    "lured %d so far...",
+    "%d devices fooled"
+};
+static const int PHRASES_HOGWASH_STATUS_COUNT = 5;
+
+void Mood::onHogwashUpdate(const char* ssid, uint8_t hookedCount, uint32_t probeCount) {
+    lastActivityTime = millis();
+    
+    char buf[48];
+    
+    if (hookedCount > 0) {
+        // Status with hook count
+        int idx = random(0, PHRASES_HOGWASH_STATUS_COUNT);
+        snprintf(buf, sizeof(buf), PHRASES_HOGWASH_STATUS[idx], hookedCount, probeCount);
+        currentPhrase = buf;
+        happiness = min(100, happiness + 2);  // Nice boost for hooks
+        applyMomentumBoost(10);
+    } else if (ssid != nullptr && ssid[0] != '\0') {
+        // Idle with SSID broadcast
+        int idx = random(0, PHRASES_HOGWASH_IDLE_COUNT);
+        currentPhrase = PHRASES_HOGWASH_IDLE[idx];
+    } else {
+        // Pure idle
+        int idx = random(0, PHRASES_HOGWASH_IDLE_COUNT);
+        currentPhrase = PHRASES_HOGWASH_IDLE[idx];
+    }
+    lastPhraseChange = millis();
+}
+

--- a/src/piglet/mood.cpp
+++ b/src/piglet/mood.cpp
@@ -1452,6 +1452,11 @@ void Mood::updateAvatarState() {
             Avatar::setState(AvatarState::ANGRY);
             break;
             
+        case PorkchopMode::HOGWASH_MODE:
+            // Karma AP mode: ALWAYS show DEVIOUS (sneaky fishing face)
+            Avatar::setState(AvatarState::DEVIOUS);
+            break;
+            
         case PorkchopMode::WARHOG_MODE:
             // Wardriving: relaxed hunting, biased toward happy
             if (effectiveMood > MOOD_PEEK_HIGH_THRESHOLD) {
@@ -1894,8 +1899,8 @@ void Mood::onHogwashUpdate(const char* ssid, uint8_t hookedCount, uint32_t probe
     static char buf[48];
     
     if (hookedCount > 0) {
-        // Mix status phrases with idle/flavor phrases (70% status, 30% flavor)
-        if (random(0, 10) < 7) {
+        // Mix status phrases with idle/flavor phrases (60% status, 40% flavor)
+        if (random(0, 10) < 6) {
             // Status with hook count
             int idx = random(0, PHRASES_HOGWASH_STATUS_COUNT);
             snprintf(buf, sizeof(buf), PHRASES_HOGWASH_STATUS[idx], hookedCount, probeCount);
@@ -1906,7 +1911,7 @@ void Mood::onHogwashUpdate(const char* ssid, uint8_t hookedCount, uint32_t probe
             currentPhrase = PHRASES_HOGWASH_IDLE[idx];
         }
         happiness = min(100, happiness + 2);  // Nice boost for hooks
-        applyMomentumBoost(10);
+        // Note: No applyMomentumBoost() here - we want to maintain DEVIOUS state
     } else if (ssid != nullptr && ssid[0] != '\0') {
         // Idle with SSID broadcast
         int idx = random(0, PHRASES_HOGWASH_IDLE_COUNT);

--- a/src/piglet/mood.h
+++ b/src/piglet/mood.h
@@ -33,6 +33,7 @@ public:
     static void onWarhogUpdate();
     static void onWarhogFound(const char* apName = nullptr, uint8_t channel = 0);
     static void onPiggyBluesUpdate(const char* vendor = nullptr, int8_t rssi = 0, uint8_t targetCount = 0, uint8_t totalFound = 0);
+    static void onHogwashUpdate(const char* ssid = nullptr, uint8_t hookedCount = 0, uint32_t probeCount = 0);
     static void resetBLESniffState();  // Reset first-target sniff flag on mode start
     
     // Get current mood phrase

--- a/src/ui/display.cpp
+++ b/src/ui/display.cpp
@@ -13,6 +13,7 @@
 #include "../modes/donoham.h"
 #include "../modes/warhog.h"
 #include "../modes/piggyblues.h"
+#include "../modes/hogwash.h"
 #include "../modes/spectrum.h"
 #include "../modes/call_papa.h"
 #include "../gps/gps.h"
@@ -126,6 +127,7 @@ void Display::update() {
         case PorkchopMode::DNH_MODE:
         case PorkchopMode::WARHOG_MODE:
         case PorkchopMode::PIGGYBLUES_MODE:
+        case PorkchopMode::HOGWASH_MODE:
         case PorkchopMode::CALL_PAPA_MODE:
             // Draw piglet avatar and mood bubble (info embedded in bubble)
             Avatar::draw(mainCanvas);
@@ -255,6 +257,10 @@ void Display::drawTopBar() {
             break;
         case PorkchopMode::PIGGYBLUES_MODE:
             modeStr = "PIGGY BLUES";
+            modeColor = COLOR_ACCENT;
+            break;
+        case PorkchopMode::HOGWASH_MODE:
+            modeStr = "HOGWASH";
             modeColor = COLOR_ACCENT;
             break;
         case PorkchopMode::SPECTRUM_MODE:
@@ -506,6 +512,23 @@ void Display::drawBottomBar() {
         uint32_t windows = PiggyBluesMode::getWindowsCount();
         char buf[48];
         snprintf(buf, sizeof(buf), "TX:%lu A:%lu G:%lu S:%lu W:%lu", total, apple, android, samsung, windows);
+        stats = String(buf);
+    } else if (mode == PorkchopMode::HOGWASH_MODE) {
+        // HOGWASH: Probes seen, unique SSIDs, hooked stations
+        uint32_t probes = HogwashMode::getProbeCount();
+        uint32_t unique = HogwashMode::getUniqueSSIDCount();
+        uint8_t hooked = HogwashMode::getHookedCount();
+        const char* ssid = HogwashMode::getCurrentSSID();
+        char buf[64];
+        if (ssid && ssid[0] != '\0') {
+            // Truncate SSID for display
+            char ssidShort[13];
+            strncpy(ssidShort, ssid, 12);
+            ssidShort[12] = '\0';
+            snprintf(buf, sizeof(buf), "P:%lu U:%lu H:%d [%s]", probes, unique, hooked, ssidShort);
+        } else {
+            snprintf(buf, sizeof(buf), "P:%lu U:%lu H:%d", probes, unique, hooked);
+        }
         stats = String(buf);
     } else if (mode == PorkchopMode::SPECTRUM_MODE) {
         // SPECTRUM: show selected network info or scan status

--- a/src/ui/settings_menu.cpp
+++ b/src/ui/settings_menu.cpp
@@ -316,6 +316,14 @@ void SettingsMenu::loadFromConfig() {
         1, 30, 1, "s", "",
         "HOGWASH SSID switch time"
     });
+    
+    // Fixed SSID (Evil Twin mode - if set, disables karma cycling)
+    items.push_back({
+        "Fixed SSID",
+        SettingType::TEXT,
+        0, 0, 32, 0, "", Config::wifi().hogwashFixedSSID,
+        "Set for Evil Twin (empty=karma)"
+    });
     // No Save & Exit button - ESC/backtick auto-saves
 }
 
@@ -387,6 +395,8 @@ void SettingsMenu::saveToConfig() {
     // HOGWASH settings
     w.hogwashCaptivePortal = items[27].value == 1;
     w.hogwashSSIDCycleMs = items[28].value * 1000;  // Convert seconds to ms
+    strncpy(w.hogwashFixedSSID, items[29].textValue.c_str(), 32);
+    w.hogwashFixedSSID[32] = '\0';
     Config::setWiFi(w);
     
     // Save to file

--- a/src/ui/settings_menu.cpp
+++ b/src/ui/settings_menu.cpp
@@ -296,6 +296,26 @@ void SettingsMenu::loadFromConfig() {
         50, 200, 25, "ms", "",
         "Per-packet duration"
     });
+    
+    // === HOGWASH Settings ===
+    
+    // Captive Portal (DNS redirect in HOGWASH mode)
+    items.push_back({
+        "Karma Portal",
+        SettingType::TOGGLE,
+        Config::wifi().hogwashCaptivePortal ? 1 : 0,
+        0, 1, 1, "", "",
+        "DNS redirect in HOGWASH"
+    });
+    
+    // SSID Cycle Time (how often to switch SSID in HOGWASH, 1-30 seconds)
+    items.push_back({
+        "SSID Cycle",
+        SettingType::VALUE,
+        (int)(Config::wifi().hogwashSSIDCycleMs / 1000),
+        1, 30, 1, "s", "",
+        "HOGWASH SSID switch time"
+    });
     // No Save & Exit button - ESC/backtick auto-saves
 }
 
@@ -363,6 +383,11 @@ void SettingsMenu::saveToConfig() {
     b.burstInterval = items[25].value;
     b.advDuration = items[26].value;
     Config::setBLE(b);
+    
+    // HOGWASH settings
+    w.hogwashCaptivePortal = items[27].value == 1;
+    w.hogwashSSIDCycleMs = items[28].value * 1000;  // Convert seconds to ms
+    Config::setWiFi(w);
     
     // Save to file
     Config::save();

--- a/test/test_hogwash/test_hogwash.cpp
+++ b/test/test_hogwash/test_hogwash.cpp
@@ -1,0 +1,434 @@
+// HOGWASH Mode Tests
+// Tests Karma AP SSID queue, probe parsing, and XP integration
+
+#include <unity.h>
+#include <cstring>
+#include <cstdio>
+#include "../mocks/testable_functions.h"
+
+void setUp(void) {
+    // No setup needed for pure function tests
+}
+
+void tearDown(void) {
+    // No teardown needed
+}
+
+// ============================================================================
+// SSID Ring Buffer Tests
+// ============================================================================
+
+// Simple ring buffer struct for testing (mirrors hogwash.cpp implementation)
+struct SSIDEntry {
+    char ssid[33];      // Max SSID + null
+    uint32_t timestamp; // When this SSID was seen
+    uint8_t probeCount; // How many times probed
+};
+
+struct SSIDQueue {
+    SSIDEntry entries[8];
+    uint8_t head;
+    uint8_t count;
+};
+
+// Initialize queue
+inline void ssidQueueInit(SSIDQueue* q) {
+    memset(q, 0, sizeof(SSIDQueue));
+}
+
+// Add SSID to queue (returns true if new, false if duplicate)
+inline bool ssidQueueAdd(SSIDQueue* q, const char* ssid, uint32_t timestamp) {
+    if (ssid == nullptr || ssid[0] == '\0') return false;
+    if (strlen(ssid) > 32) return false;
+    
+    // Check for duplicate
+    for (uint8_t i = 0; i < q->count; i++) {
+        uint8_t idx = (q->head + i) % 8;
+        if (strcmp(q->entries[idx].ssid, ssid) == 0) {
+            // Update timestamp and increment probe count
+            q->entries[idx].timestamp = timestamp;
+            q->entries[idx].probeCount++;
+            return false;  // Duplicate
+        }
+    }
+    
+    // Add new entry
+    uint8_t newIdx;
+    if (q->count < 8) {
+        newIdx = (q->head + q->count) % 8;
+        q->count++;
+    } else {
+        // Queue full, overwrite oldest (head)
+        newIdx = q->head;
+        q->head = (q->head + 1) % 8;
+    }
+    
+    strncpy(q->entries[newIdx].ssid, ssid, 32);
+    q->entries[newIdx].ssid[32] = '\0';
+    q->entries[newIdx].timestamp = timestamp;
+    q->entries[newIdx].probeCount = 1;
+    
+    return true;  // New entry
+}
+
+// Get most recent SSID (for broadcasting)
+inline const char* ssidQueueGetLatest(const SSIDQueue* q) {
+    if (q->count == 0) return nullptr;
+    uint8_t latestIdx = (q->head + q->count - 1) % 8;
+    return q->entries[latestIdx].ssid;
+}
+
+// Get SSID count
+inline uint8_t ssidQueueCount(const SSIDQueue* q) {
+    return q->count;
+}
+
+void test_ssidQueue_init_empty(void) {
+    SSIDQueue q;
+    ssidQueueInit(&q);
+    TEST_ASSERT_EQUAL_UINT8(0, ssidQueueCount(&q));
+    TEST_ASSERT_NULL(ssidQueueGetLatest(&q));
+}
+
+void test_ssidQueue_add_single(void) {
+    SSIDQueue q;
+    ssidQueueInit(&q);
+    
+    bool isNew = ssidQueueAdd(&q, "TestNetwork", 1000);
+    TEST_ASSERT_TRUE(isNew);
+    TEST_ASSERT_EQUAL_UINT8(1, ssidQueueCount(&q));
+    TEST_ASSERT_EQUAL_STRING("TestNetwork", ssidQueueGetLatest(&q));
+}
+
+void test_ssidQueue_add_duplicate(void) {
+    SSIDQueue q;
+    ssidQueueInit(&q);
+    
+    ssidQueueAdd(&q, "TestNetwork", 1000);
+    bool isNew = ssidQueueAdd(&q, "TestNetwork", 2000);
+    
+    TEST_ASSERT_FALSE(isNew);  // Duplicate
+    TEST_ASSERT_EQUAL_UINT8(1, ssidQueueCount(&q));  // Still 1
+}
+
+void test_ssidQueue_add_multiple(void) {
+    SSIDQueue q;
+    ssidQueueInit(&q);
+    
+    ssidQueueAdd(&q, "Network1", 1000);
+    ssidQueueAdd(&q, "Network2", 2000);
+    ssidQueueAdd(&q, "Network3", 3000);
+    
+    TEST_ASSERT_EQUAL_UINT8(3, ssidQueueCount(&q));
+    TEST_ASSERT_EQUAL_STRING("Network3", ssidQueueGetLatest(&q));
+}
+
+void test_ssidQueue_overflow_wraps(void) {
+    SSIDQueue q;
+    ssidQueueInit(&q);
+    
+    // Fill queue with 8 entries
+    for (int i = 0; i < 8; i++) {
+        char ssid[20];
+        snprintf(ssid, sizeof(ssid), "Net%d", i);
+        ssidQueueAdd(&q, ssid, i * 1000);
+    }
+    
+    TEST_ASSERT_EQUAL_UINT8(8, ssidQueueCount(&q));
+    
+    // Add 9th entry - should overwrite oldest
+    ssidQueueAdd(&q, "Net8", 8000);
+    
+    TEST_ASSERT_EQUAL_UINT8(8, ssidQueueCount(&q));  // Still max 8
+    TEST_ASSERT_EQUAL_STRING("Net8", ssidQueueGetLatest(&q));
+}
+
+void test_ssidQueue_rejects_null(void) {
+    SSIDQueue q;
+    ssidQueueInit(&q);
+    
+    bool isNew = ssidQueueAdd(&q, nullptr, 1000);
+    TEST_ASSERT_FALSE(isNew);
+    TEST_ASSERT_EQUAL_UINT8(0, ssidQueueCount(&q));
+}
+
+void test_ssidQueue_rejects_empty(void) {
+    SSIDQueue q;
+    ssidQueueInit(&q);
+    
+    bool isNew = ssidQueueAdd(&q, "", 1000);
+    TEST_ASSERT_FALSE(isNew);
+    TEST_ASSERT_EQUAL_UINT8(0, ssidQueueCount(&q));
+}
+
+void test_ssidQueue_rejects_too_long(void) {
+    SSIDQueue q;
+    ssidQueueInit(&q);
+    
+    // 33 character SSID (max is 32)
+    bool isNew = ssidQueueAdd(&q, "123456789012345678901234567890123", 1000);
+    TEST_ASSERT_FALSE(isNew);
+    TEST_ASSERT_EQUAL_UINT8(0, ssidQueueCount(&q));
+}
+
+void test_ssidQueue_32_char_ssid_ok(void) {
+    SSIDQueue q;
+    ssidQueueInit(&q);
+    
+    // Exactly 32 characters (max valid)
+    bool isNew = ssidQueueAdd(&q, "12345678901234567890123456789012", 1000);
+    TEST_ASSERT_TRUE(isNew);
+    TEST_ASSERT_EQUAL_UINT8(1, ssidQueueCount(&q));
+}
+
+// ============================================================================
+// Probe Request Parsing Tests
+// ============================================================================
+
+// Parse SSID from probe request frame
+// Probe request format: [24 byte header][Tagged params]
+// Tag 0 = SSID: [tag=0][length][ssid bytes]
+inline bool parseProbeSSID(const uint8_t* frame, uint16_t len, char* ssidOut, uint8_t maxLen) {
+    if (frame == nullptr || len < 26 || ssidOut == nullptr) return false;
+    
+    // Skip 24 byte MAC header, start at tagged parameters
+    const uint8_t* tagPtr = frame + 24;
+    const uint8_t* endPtr = frame + len;
+    
+    while (tagPtr + 2 <= endPtr) {
+        uint8_t tagNum = tagPtr[0];
+        uint8_t tagLen = tagPtr[1];
+        
+        if (tagPtr + 2 + tagLen > endPtr) break;  // Invalid length
+        
+        if (tagNum == 0) {  // SSID tag
+            if (tagLen == 0) {
+                ssidOut[0] = '\0';  // Broadcast probe (empty SSID)
+                return true;
+            }
+            if (tagLen > maxLen - 1) return false;  // Too long for buffer
+            memcpy(ssidOut, tagPtr + 2, tagLen);
+            ssidOut[tagLen] = '\0';
+            return true;
+        }
+        
+        tagPtr += 2 + tagLen;  // Move to next tag
+    }
+    
+    return false;  // No SSID tag found
+}
+
+void test_parseProbeSSID_valid_ssid(void) {
+    // Probe request with SSID "Test"
+    uint8_t frame[30] = {0};
+    // Tag 0 (SSID), length 4, "Test"
+    frame[24] = 0x00;
+    frame[25] = 0x04;
+    frame[26] = 'T';
+    frame[27] = 'e';
+    frame[28] = 's';
+    frame[29] = 't';
+    
+    char ssid[33] = {0};
+    bool result = parseProbeSSID(frame, 30, ssid, sizeof(ssid));
+    
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_EQUAL_STRING("Test", ssid);
+}
+
+void test_parseProbeSSID_broadcast_probe(void) {
+    // Broadcast probe (empty SSID)
+    uint8_t frame[26] = {0};
+    frame[24] = 0x00;  // SSID tag
+    frame[25] = 0x00;  // Length 0
+    
+    char ssid[33] = "garbage";
+    bool result = parseProbeSSID(frame, 26, ssid, sizeof(ssid));
+    
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_EQUAL_STRING("", ssid);
+}
+
+void test_parseProbeSSID_frame_too_short(void) {
+    uint8_t frame[20] = {0};
+    char ssid[33];
+    
+    bool result = parseProbeSSID(frame, 20, ssid, sizeof(ssid));
+    TEST_ASSERT_FALSE(result);
+}
+
+void test_parseProbeSSID_null_frame(void) {
+    char ssid[33];
+    bool result = parseProbeSSID(nullptr, 30, ssid, sizeof(ssid));
+    TEST_ASSERT_FALSE(result);
+}
+
+void test_parseProbeSSID_long_ssid(void) {
+    // 32 byte SSID (maximum)
+    uint8_t frame[58] = {0};
+    frame[24] = 0x00;  // SSID tag
+    frame[25] = 32;    // Length 32
+    for (int i = 0; i < 32; i++) {
+        frame[26 + i] = 'A' + (i % 26);
+    }
+    
+    char ssid[33] = {0};
+    bool result = parseProbeSSID(frame, 58, ssid, sizeof(ssid));
+    
+    TEST_ASSERT_TRUE(result);
+    TEST_ASSERT_EQUAL_UINT8(32, strlen(ssid));
+}
+
+// ============================================================================
+// Achievement2 Bitfield Tests (second uint64_t for HOGWASH achievements)
+// ============================================================================
+
+// Check if achievement is unlocked in second bitfield
+inline bool hasAchievement2(uint64_t achievements2, uint64_t achievementBit) {
+    return (achievements2 & achievementBit) != 0;
+}
+
+// Unlock achievement in second bitfield
+inline uint64_t unlockAchievement2(uint64_t achievements2, uint64_t achievementBit) {
+    return achievements2 | achievementBit;
+}
+
+// HOGWASH achievement bits (in achievements2 field)
+#define ACH2_FIRST_HOOK     (1ULL << 0)   // First device hooked via Karma
+#define ACH2_KARMA_KING     (1ULL << 1)   // 50 devices hooked lifetime
+#define ACH2_HONEY_POT      (1ULL << 2)   // 5 devices connected simultaneously
+#define ACH2_TRAP_MASTER    (1ULL << 3)   // 100 unique SSIDs captured
+#define ACH2_APPLE_PICKER   (1ULL << 4)   // Hook 10 Apple devices
+#define ACH2_TRAFFIC_WARDEN (1ULL << 5)   // 30 minutes continuous HOGWASH
+
+void test_hasAchievement2_empty(void) {
+    TEST_ASSERT_FALSE(hasAchievement2(0, ACH2_FIRST_HOOK));
+    TEST_ASSERT_FALSE(hasAchievement2(0, ACH2_KARMA_KING));
+}
+
+void test_hasAchievement2_single(void) {
+    uint64_t ach2 = ACH2_FIRST_HOOK;
+    TEST_ASSERT_TRUE(hasAchievement2(ach2, ACH2_FIRST_HOOK));
+    TEST_ASSERT_FALSE(hasAchievement2(ach2, ACH2_KARMA_KING));
+}
+
+void test_unlockAchievement2_first(void) {
+    uint64_t ach2 = 0;
+    ach2 = unlockAchievement2(ach2, ACH2_FIRST_HOOK);
+    TEST_ASSERT_EQUAL_UINT64(ACH2_FIRST_HOOK, ach2);
+}
+
+void test_unlockAchievement2_preserves_existing(void) {
+    uint64_t ach2 = ACH2_FIRST_HOOK | ACH2_HONEY_POT;
+    ach2 = unlockAchievement2(ach2, ACH2_KARMA_KING);
+    
+    TEST_ASSERT_TRUE(hasAchievement2(ach2, ACH2_FIRST_HOOK));
+    TEST_ASSERT_TRUE(hasAchievement2(ach2, ACH2_HONEY_POT));
+    TEST_ASSERT_TRUE(hasAchievement2(ach2, ACH2_KARMA_KING));
+}
+
+void test_unlockAchievement2_idempotent(void) {
+    uint64_t ach2 = ACH2_FIRST_HOOK;
+    uint64_t ach2_again = unlockAchievement2(ach2, ACH2_FIRST_HOOK);
+    TEST_ASSERT_EQUAL_UINT64(ach2, ach2_again);
+}
+
+// ============================================================================
+// XP Anti-Farm Cap Tests
+// ============================================================================
+
+struct HogwashSessionStats {
+    uint16_t probeXP;
+    uint16_t hookXP;
+    bool capWarned;
+};
+
+const uint16_t HOGWASH_PROBE_XP_CAP = 200;  // Max XP from probes per session
+
+inline uint16_t applyHogwashXPCap(HogwashSessionStats* stats, uint16_t xpToAdd, bool isProbeEvent) {
+    if (!isProbeEvent) {
+        stats->hookXP += xpToAdd;
+        return xpToAdd;  // Hook XP not capped
+    }
+    
+    if (stats->probeXP >= HOGWASH_PROBE_XP_CAP) {
+        if (!stats->capWarned) {
+            stats->capWarned = true;
+        }
+        return 0;  // Capped
+    }
+    
+    uint16_t remaining = HOGWASH_PROBE_XP_CAP - stats->probeXP;
+    uint16_t awarded = (xpToAdd <= remaining) ? xpToAdd : remaining;
+    stats->probeXP += awarded;
+    return awarded;
+}
+
+void test_hogwashXPCap_under_limit(void) {
+    HogwashSessionStats stats = {0};
+    uint16_t awarded = applyHogwashXPCap(&stats, 10, true);
+    TEST_ASSERT_EQUAL_UINT16(10, awarded);
+    TEST_ASSERT_EQUAL_UINT16(10, stats.probeXP);
+}
+
+void test_hogwashXPCap_at_limit(void) {
+    HogwashSessionStats stats = {.probeXP = 195, .hookXP = 0, .capWarned = false};
+    uint16_t awarded = applyHogwashXPCap(&stats, 10, true);
+    TEST_ASSERT_EQUAL_UINT16(5, awarded);  // Only 5 remaining
+    TEST_ASSERT_EQUAL_UINT16(200, stats.probeXP);
+}
+
+void test_hogwashXPCap_over_limit(void) {
+    HogwashSessionStats stats = {.probeXP = 200, .hookXP = 0, .capWarned = false};
+    uint16_t awarded = applyHogwashXPCap(&stats, 10, true);
+    TEST_ASSERT_EQUAL_UINT16(0, awarded);
+    TEST_ASSERT_TRUE(stats.capWarned);
+}
+
+void test_hogwashXPCap_hook_not_capped(void) {
+    HogwashSessionStats stats = {.probeXP = 200, .hookXP = 0, .capWarned = true};
+    uint16_t awarded = applyHogwashXPCap(&stats, 25, false);  // Hook event
+    TEST_ASSERT_EQUAL_UINT16(25, awarded);  // Hooks not capped
+    TEST_ASSERT_EQUAL_UINT16(25, stats.hookXP);
+}
+
+// ============================================================================
+// Main
+// ============================================================================
+
+int main(int argc, char **argv) {
+    UNITY_BEGIN();
+    
+    // SSID Queue tests
+    RUN_TEST(test_ssidQueue_init_empty);
+    RUN_TEST(test_ssidQueue_add_single);
+    RUN_TEST(test_ssidQueue_add_duplicate);
+    RUN_TEST(test_ssidQueue_add_multiple);
+    RUN_TEST(test_ssidQueue_overflow_wraps);
+    RUN_TEST(test_ssidQueue_rejects_null);
+    RUN_TEST(test_ssidQueue_rejects_empty);
+    RUN_TEST(test_ssidQueue_rejects_too_long);
+    RUN_TEST(test_ssidQueue_32_char_ssid_ok);
+    
+    // Probe parsing tests
+    RUN_TEST(test_parseProbeSSID_valid_ssid);
+    RUN_TEST(test_parseProbeSSID_broadcast_probe);
+    RUN_TEST(test_parseProbeSSID_frame_too_short);
+    RUN_TEST(test_parseProbeSSID_null_frame);
+    RUN_TEST(test_parseProbeSSID_long_ssid);
+    
+    // Achievement2 tests
+    RUN_TEST(test_hasAchievement2_empty);
+    RUN_TEST(test_hasAchievement2_single);
+    RUN_TEST(test_unlockAchievement2_first);
+    RUN_TEST(test_unlockAchievement2_preserves_existing);
+    RUN_TEST(test_unlockAchievement2_idempotent);
+    
+    // XP cap tests
+    RUN_TEST(test_hogwashXPCap_under_limit);
+    RUN_TEST(test_hogwashXPCap_at_limit);
+    RUN_TEST(test_hogwashXPCap_over_limit);
+    RUN_TEST(test_hogwashXPCap_hook_not_capped);
+    
+    return UNITY_END();
+}


### PR DESCRIPTION
# HOGWASH Mode - Karma AP / Evil Twin Implementation

## Summary

This PR introduces **HOGWASH Mode**, a new operational mode that implements a Karma Access Point attack. The pig listens for WiFi probe requests from nearby devices, extracts the SSIDs they're looking for, and broadcasts a matching fake AP to lure them in.

##  Features

### Core Karma AP Functionality
- **Probe Request Capture**: Monitors WiFi probe requests in promiscuous mode
- **SSID Cycling**: Broadcasts as the last probed SSID to attract devices
- **Smart Rotation**: SSID cycling pauses while clients are connected (10s disconnect detection)
- **Hook Detection**: Tracks connected stations with Apple device identification
- **MAC Randomization Detection**: Shows `[RandomMAC]` when devices use randomized addresses

### Captive Portal
- **DNS Redirect**: All domains redirect to the AP (192.168.4.1)
- **HTTP Server**: Serves portal HTML on port 80
- **Custom Portal**: Drop `/portal.html` on SD card for custom pages
- **Platform Detection**: Handles Android, iOS, macOS, and Windows captive portal endpoints

### XP & Achievements System
| Event | XP | Cap |
|-------|-----|-----|
| `HOGWASH_PROBE_NEW` | +3 | 200/session |
| `HOGWASH_HOOK` | +25 | - |
| `HOGWASH_APPLE_HOOK` | +35 | - |
| `HOGWASH_SESSION_5MIN` | +10 | - |

**6 New Achievements:**
- `F1RST H00K` - First device hooked
- `K4RMA K1NG` - 50 devices hooked lifetime
- `H0N3Y P0T` - 5 devices connected simultaneously  
- `TR4P M4ST3R` - 100 unique SSIDs captured
- `4PPL3 P1CK3R` - Hook 10 Apple devices
- `TR4FF1C W4RD3N` - 30 minutes continuous operation

### Avatar & Mood
- **DEVIOUS State**: New sneaky avatar face (`> >` eyes, `~` expression)
- **Probe Phrases**: "I am [SSID] now", "looking for [SSID]?", etc.
- **Hook Phrases**: "GOTCHA!", "yoink", "GET OVER HERE"
- **Mixed Status/Flavor**: 60% stats, 40% flavor phrases during operation

### UI & Settings
- **Bottom Bar**: Shows `P:probes U:unique H:hooked [SSID]`
- **Sound Notifications**: Double beep for hooks, triple for Apple devices
- **Settings**:
  - `Karma Portal`: Toggle captive portal (default: OFF)
  - `SSID Cycle`: 1-30 seconds (default: 5s)
  - `Fixed SSID`: When set, HOGWASH mode operates as an Evil Twin attack instead of Karma AP

## Files Changed

### New Files
- `src/modes/hogwash.cpp` - Core implementation (~700 lines)
- `src/modes/hogwash.h` - Mode interface and structures

### Modified Files
- `src/core/porkchop.cpp/.h` - Mode integration (K key binding)
- `src/core/xp.cpp/.h` - XP events and achievements2 field
- `src/core/config.cpp/.h` - Settings (portal toggle, cycle time)
- `src/piglet/avatar.cpp/.h` - DEVIOUS state and frames
- `src/piglet/mood.cpp/.h` - Phrases and onHogwashUpdate()
- `src/ui/display.cpp` - UI elements and bottom bar
- `src/ui/settings_menu.cpp` - New settings items
- `README.md` - Full documentation

### Tests
- `test/test_hogwash/test_hogwash.cpp` - 33 test cases covering:
  - SSID queue operations
  - Probe request parsing
  - Achievement2 bitfield operations
  - XP anti-farm cap logic
  - Captive portal HTML loading
  - Platform endpoint detection

## Technical Details

### WiFi Stack
- Uses ESP32 promiscuous mode for probe capture
- Soft AP with dynamic SSID switching
- `esp_wifi_set_inactive_time(10)` for fast disconnect detection
- Mixed ESP-IDF and Arduino WiFi API usage

### Memory
- RAM: 23.1% (75.5KB / 327KB)
- Flash: 53.7% (1.69MB / 3.15MB)

### Key Design Decisions
1. **Deferred XP**: Probe callback runs in WiFi task; XP grants queued for main loop
2. **achievements2 field**: Uses second uint64_t for HOGWASH achievements (NVS compatible)
3. **Station Count**: Uses `WiFi.softAPgetStationNum()` for real-time client detection
4. **Inactivity Timeout**: 10 seconds instead of default 300s for responsive cycling

## Disclaimer

HOGWASH mode demonstrates Karma AP/Evil twin attacks for **educational purposes only**. Use responsibly on your own devices. The same legal considerations as PIGGY BLUES apply.

## Testing

```bash
# Run HOGWASH tests
pio test -e native --filter "test_hogwash"

# Build for device
pio run -e m5cardputer

# Flash and monitor
pio run -e m5cardputer -t upload && pio device monitor -b 115200
```

## Commits (17 total)

See individual commit messages for detailed changes. Key commits:
- `a2e26a4` - Core implementation
- `38e89f9` - Captive portal
- `072af77` - SSID rotation fixes
- `88f00c7` - DEVIOUS avatar persistence