### PR TITLE
Fix D key starting OINK instead of DNH from IDLE

### DIFF
--- a/src/core/porkchop.cpp
+++ b/src/core/porkchop.cpp
@@ -539,7 +539,7 @@ void Porkchop::handleInput() {
                 case 'd': // DO NO HAM mode
                 case 'D':
                     setMode(PorkchopMode::DNH_MODE);
-                    break;
+                    return; // Prevent fall-through to DNH handler
                 case 'f': // File transfer (PORKCHOP COMMANDER)
                 case 'F':
                     setMode(PorkchopMode::FILE_TRANSFER);


### PR DESCRIPTION
Problem:

- Pressing D in IDLE mode starts OINK_MODE instead of DNH_MODE
- Expected: IDLE → (D key) → DNH_MODE
- Actual: IDLE → (D key) → DNH_MODE → OINK_MODE (immediately)

Root cause:

- IDLE handler sets DNH_MODE but continues executing handleInput()
- DNH mode handler runs in the same frame
- DNH handler detects D key still pressed and switches to OINK_MODE
- dWasPressed_dnh doesn't help because it's the first frame in DNH mode
- Mode transition completes but input handler doesn't exit

Solution:

- Add return after setMode(PorkchopMode::DNH_MODE) in IDLE handler
- Prevents DNH handler from running until next frame
- Matches existing pattern from OINK↔DNH transitions

Testing:

- Tested on M5Cardputer ADV
- Verified D key from IDLE now correctly enters DNH_MODE
- Verified D key still toggles between OINK↔DNH as expected

Files changed:

- `src/core/porkchop.cpp`: Added return statement at line 542